### PR TITLE
Hotfix #1

### DIFF
--- a/src/Panel.tsx
+++ b/src/Panel.tsx
@@ -133,19 +133,24 @@ export const Panel: React.FC<PanelProps> = (props) => {
   const storyId = useStorybookState().storyId;
   const data = api.getData(storyId);
 
-  if (!states?.selectedPanel?.includes(ADDON_ID)) return undefined;
-
-  if (!isStoryReady(data)) return <Placeholder>Initializing..</Placeholder>;
+  if (!isStoryReady(data))
+    return (
+      <AddonPanel {...props} key={storyId}>
+        <Placeholder>Initializing..</Placeholder>
+      </AddonPanel>
+    );
 
   if (!source)
     return (
-      <Container>
-        <NoSource />
-      </Container>
+      <AddonPanel key={storyId} {...props}>
+        <Container>
+          <NoSource />
+        </Container>
+      </AddonPanel>
     );
 
   return (
-    <AddonPanel {...props}>
+    <AddonPanel {...props} key={storyId}>
       <Container>
         <Nav>
           <Tray>

--- a/src/components/actionTray/EditButton.tsx
+++ b/src/components/actionTray/EditButton.tsx
@@ -21,6 +21,7 @@ import {
 import { BaseButton, Tooltip, Arrow } from "./BaseButton";
 import { EVENTS } from "../../constants";
 import { extractAttributeFromTag } from "../../tools";
+import { Args } from "@storybook/types";
 
 interface Props {
   hoverTitle?: string;
@@ -44,11 +45,15 @@ const getUpdatedArgs = (code: string) =>
 const defaultOnClick = (
   code: string,
   updateArgs: Function,
-  resetArgs: Function
+  defaultArgs: Args
 ) => {
   addons.getChannel().emit(EVENTS.SET_PERMUTATIONS, "", "clear");
-  const args = getUpdatedArgs(code);
-  resetArgs();
+  const updatedArgs = getUpdatedArgs(code);
+  const clearArgs = R.mapObjIndexed((value, key) => {
+    if (typeof value === "boolean") return false;
+    return value;
+  }, defaultArgs);
+  const args = R.mergeRight(clearArgs, updatedArgs);
   updateArgs(args);
 };
 
@@ -94,7 +99,7 @@ export const EditButton = ({
 
   // handler
   const handleClick = (e: any) =>
-    onClick ? onClick(e) : defaultOnClick(code, updateArgs, resetArgs);
+    onClick ? onClick(e) : defaultOnClick(code, updateArgs, args);
 
   return (
     <div
@@ -102,16 +107,7 @@ export const EditButton = ({
       {...getReferenceProps}
       onMouseLeave={() => setText(hoverTitle)}
     >
-      <BaseButton
-        title={hoverTitle}
-        // FIX:handleClick 삭제하던가... 아니면 event가 안내려오도록 잘 하던가
-        // onClick={(e) => {
-        //   resetArgs();
-        //   defaultOnClick(code, updateArgs);
-        // }}
-        onClick={handleClick}
-        icon={icon}
-      />
+      <BaseButton title={hoverTitle} onClick={handleClick} icon={icon} />
       <FloatingPortal>
         {isOpen && text && (
           <Tooltip

--- a/src/components/actionTray/EditButton.tsx
+++ b/src/components/actionTray/EditButton.tsx
@@ -41,9 +41,14 @@ const getUpdatedArgs = (code: string) =>
     }, {})
   )([code]);
 
-const defaultOnClick = (code: string, updateArgs: Function) => {
+const defaultOnClick = (
+  code: string,
+  updateArgs: Function,
+  resetArgs: Function
+) => {
   addons.getChannel().emit(EVENTS.SET_PERMUTATIONS, "", "clear");
   const args = getUpdatedArgs(code);
+  resetArgs();
   updateArgs(args);
 };
 
@@ -54,7 +59,7 @@ export const EditButton = ({
   clickTitle = "",
   icon = "edit",
   code,
-  onClick = defaultOnClick,
+  onClick,
 }: Props) => {
   const [args, updateArgs, resetArgs] = useArgs();
 
@@ -89,7 +94,7 @@ export const EditButton = ({
 
   // handler
   const handleClick = (e: any) =>
-    onClick ? onClick(e) : defaultOnClick(code, updateArgs);
+    onClick ? onClick(e) : defaultOnClick(code, updateArgs, resetArgs);
 
   return (
     <div
@@ -97,7 +102,16 @@ export const EditButton = ({
       {...getReferenceProps}
       onMouseLeave={() => setText(hoverTitle)}
     >
-      <BaseButton title={hoverTitle} onClick={handleClick} icon={icon} />
+      <BaseButton
+        title={hoverTitle}
+        // FIX:handleClick 삭제하던가... 아니면 event가 안내려오도록 잘 하던가
+        // onClick={(e) => {
+        //   resetArgs();
+        //   defaultOnClick(code, updateArgs);
+        // }}
+        onClick={handleClick}
+        icon={icon}
+      />
       <FloatingPortal>
         {isOpen && text && (
           <Tooltip

--- a/src/components/tooltips/tooltips.tsx
+++ b/src/components/tooltips/tooltips.tsx
@@ -1,1 +1,0 @@
-import { useState } from "react";

--- a/src/stories/Button.tsx
+++ b/src/stories/Button.tsx
@@ -22,6 +22,8 @@ interface ButtonProps {
    * Optional click handler
    */
   onClick?: () => void;
+  fake?: boolean;
+  foo?: boolean;
 }
 
 /**

--- a/src/stories/Button.tsx
+++ b/src/stories/Button.tsx
@@ -22,8 +22,6 @@ interface ButtonProps {
    * Optional click handler
    */
   onClick?: () => void;
-  fake?: boolean;
-  foo?: boolean;
 }
 
 /**

--- a/src/tools/table.ts
+++ b/src/tools/table.ts
@@ -8,7 +8,7 @@ const mapJoin = (fn: (...args: any) => any, list: any[], token = "") =>
   R.pipe(indexMap(fn), R.join(token))(list);
 
 const isLastElement = (i: number, list: any[]) =>
-  i + 1 === list.length ? "--last" : undefined;
+  i + 1 === list.length ? "--last" : "";
 
 export function getPreviewCode(
   sourceList: string[],
@@ -63,12 +63,13 @@ const TableBody = (
   const tcontents = verticalCombinationList
     .map((elem, index) => {
       const values = mapJoin(
-        (e, i) =>
-          `<td className="${isLastElement(
-            i,
-            R.values(elem)
-          )}" key="${i}">${e}</td>`,
-        R.values(elem)
+        ([key, value], i) => `<td className="${isLastElement(
+          i,
+          R.toPairs(elem)
+        )}"
+        key="${key}-${i}"
+        >${value}</td>`,
+        R.toPairs(elem)
       );
 
       const horizenFinderList = R.map((e: { [x: string]: any }) =>
@@ -92,13 +93,13 @@ const TableBody = (
 
       const options = mapJoin(
         (e, i) => `<td role='component'
-        key="${i}"
         data-target='${extractAttributeFromTag(e)}'
+        key="${extractAttributeFromTag(e)}"
         >${e}</td>`,
         R.flatten(matched)
       );
 
-      return `
+      return ` 
     <tr key="${index}">
         ${values}
         ${options}
@@ -122,10 +123,7 @@ const TableHead = (horizen: Property, verticals: Property[]) => {
       <tr role="row">
                 ${mapJoin(
                   (e, i) =>
-                    `<th className="${isLastElement(
-                      i,
-                      verticals
-                    )}" key="${i}"></th>`,
+                    `<th className="${isLastElement(i, verticals)}"></th>`,
                   verticals
                 )}
             <th colSpan="${horizen.values.length}">${horizen.prop}</th>
@@ -133,12 +131,12 @@ const TableHead = (horizen: Property, verticals: Property[]) => {
         <tr role='row' style={{boxShadow:'0px 1px #bbb'}}>
             ${mapJoin(
               (e, i) =>
-                `<th className="${isLastElement(i, verticals)}" key="${i}">${
+                `<th className="${isLastElement(i, verticals)}" key="${
                   e.prop
-                }</th>`,
+                }">${e.prop}</th>`,
               verticals
             )}
-            ${mapJoin((e, i) => `<th key="${i}">${e}</th>`, horizen.values)}
+            ${mapJoin((e, i) => `<th key="${e}">${e}</th>`, horizen.values)}
         </tr>
     </thead>
     `;


### PR DESCRIPTION
fix: unexpected render error in preview due to react keys
- react key의 중복 지정으로 인해, 테이블 행/열 변경이 부정확하게 일어나는 문제 수정

fix : add key props to panels
- 각 패널 component에 key 부여,
- sb에서 제공하는 AddonPanel을 component wrapper로 사용하여 permutation panel이 다른 패널과 동시에 보이지 않도록 조치

remove: unused file
- 사용되고 있지 않던 tooltip component 삭제