### PR TITLE
fix: global style override for permutation table

### DIFF
--- a/src/withPermutation.tsx
+++ b/src/withPermutation.tsx
@@ -54,7 +54,7 @@ const Wrapper = styled.div<{
     width: 100%;
   }
   table#permutation-table .permutation-inner-table td,
-  th {
+  table#permutation-table th {
     width: auto;
     min-width: 50px;
     padding: 0.5em;


### PR DESCRIPTION
This rule applied to all th's on the page, because there was no specifier for the permutation table in front of it.

This made it so, storybook components that use th's also get that rule applied, which resulted in tables that were incorrectly styled.