### PR TITLE
Adding Version Dependencies on Project

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,6 +73,9 @@
     "typescript": "^5.5.4",
     "vite": "^5.4.2"
   },
+  "peerDependencies": {
+    "storybook": "^8.5.0"
+  },
   "publishConfig": {
     "access": "public"
   },

--- a/src/components/manager/panelBlocks/ArgTable.tsx
+++ b/src/components/manager/panelBlocks/ArgTable.tsx
@@ -137,6 +137,7 @@ const PermTableBody = ({ rows, elem, theme, updateArgs, param }: any) => {
         <PermutationCell data-permutation={key} className="body">
           <button
             onClick={(e: any) => permutationHandlerFn(e, key)}
+            //onClick={(e: any) => permutationHandlerFn(e, displayKey)}
             className="__permtation-table-button"
           >
             <LightningIcon />
@@ -167,6 +168,7 @@ const PermTableBody = ({ rows, elem, theme, updateArgs, param }: any) => {
         <PermutationCell data-permutation={key} className="body">
           <button
             onClick={(e: any) => permutationHandlerFn(e, key)}
+            //onClick={(e: any) => permutationHandlerFn(e, displayKey)}
             className="__permtation-table-button"
           >
             <LightningIcon />

--- a/src/stories/Button.tsx
+++ b/src/stories/Button.tsx
@@ -1,5 +1,5 @@
-import React from 'react';
-import './button.css';
+import React from "react";
+import "./button.css";
 
 interface ButtonProps {
   /**
@@ -13,7 +13,7 @@ interface ButtonProps {
   /**
    * How large should the button be?
    */
-  size?: 'small' | 'medium' | 'large';
+  size?: "small" | "medium" | "large";
   /**
    * Button contents
    */
@@ -29,16 +29,20 @@ interface ButtonProps {
  */
 export const Button = ({
   primary = false,
-  size = 'medium',
+  size = "medium",
   backgroundColor,
   label,
   ...props
 }: ButtonProps) => {
-  const mode = primary ? 'storybook-button--primary' : 'storybook-button--secondary';
+  const mode = primary
+    ? "storybook-button--primary"
+    : "storybook-button--secondary";
   return (
     <button
       type="button"
-      className={['storybook-button', `storybook-button--${size}`, mode].join(' ')}
+      className={["storybook-button", `storybook-button--${size}`, mode].join(
+        " ",
+      )}
       style={{ backgroundColor }}
       {...props}
     >

--- a/src/tools/permutations.ts
+++ b/src/tools/permutations.ts
@@ -1,4 +1,10 @@
-import { Args, ArgTypes } from "@storybook/types";
+import {
+  Args,
+  ArgTypes,
+  InputType,
+  StrictArgTypes,
+  StrictInputType,
+} from "@storybook/types";
 import * as R from "ramda";
 import { attrMatchingRegex, overOneSpaceRegex } from "../utils/regex";
 
@@ -10,21 +16,26 @@ export interface Property {
 export interface Combination {
   [key: string]: any;
 }
-export const getConvertedList = (permutations: string[], argTypes: any) => {
-  const convert = (elem: ArgTypes[0]) => {
-    if (!permutations.includes(elem.name)) return;
-    switch (elem.control.type) {
+export const getConvertedList = (
+  permutations: string[],
+  argTypes: StrictArgTypes<Args>,
+) => {
+  const convert = ([key, value]: [string, StrictInputType]) => {
+    const displayKey = key;
+    if (!permutations.includes(displayKey)) return;
+    switch (value.control.type) {
       case "select":
       case "radio":
-        return { prop: elem.name, values: elem.options };
+        return { prop: displayKey, values: value.options };
       case "boolean":
-        return { prop: elem.name, values: [true, false] };
+        return { prop: displayKey, values: [true, false] };
       default:
         return;
     }
   };
 
   return R.pipe(
+    R.toPairs,
     R.map(convert),
     R.values,
     R.reject(R.isNil),
@@ -90,16 +101,13 @@ export const convertArgTypeToArg = (argType: ArgTypes<Args>) => {
   const arg = Object.entries(argType).map((elem) => {
     // const [key, value] = elem;
     const [k, value] = elem;
-    const key = value.name;
 
     switch (value.control?.type) {
       case "select":
       case "radio":
         return { prop: k, values: value.options };
-      // return { prop: key, values: value.options };
       case "boolean":
         return { prop: k, values: [true, false] };
-      // return { prop: key, values: [true, false] };
       case "object":
       default:
         return;

--- a/src/withPermutation.tsx
+++ b/src/withPermutation.tsx
@@ -84,6 +84,7 @@ export const withPermutation = (
 
   const autoload = context.parameters["permutation"]?.autoload ?? [];
   const deactivate = context.parameters.permutation?.deactivate ?? [];
+  // 실제 component의 arg를 가지고 있는 argKeys
   const argKeys = convertArgTypeToArg(context.argTypes);
 
   const autoPermutation =


### PR DESCRIPTION
Solving [#46](#46).

We raised the base of the project from React 18 to React 19, but we also raised the version of Storybook that it depends on, which made it unusable for people using older versions of Storybook. We added a peer dependency to prevent this from happening in the package manager, but we need a better solution.


*We also fixed an issue that prevented Tables from working properly in stories that use Altnames.